### PR TITLE
Add permission limits for lay/crawl/spin

### DIFF
--- a/resources/lang/tr_tr.yml
+++ b/resources/lang/tr_tr.yml
@@ -11,7 +11,7 @@ Plugin:
 
 Messages:
 
-  command-permission-error: "[P]&c Bu komutu kullanma yetkiniz yok!"
+  command-permission-error: "[P]&c Bu komutu kullanmaya yetkin yok."
   command-sender-error: "[P]&c Bu komutu çalıştıramazsın!"
   command-version-error: "[P]&c Eski sunucu sürümü! (&b%Version%&c)\n[P]&c Bu özelliği kullanabilmek için sunucunuzu yükseltin!"
 

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -42,6 +42,7 @@ commands:
     usage: /<command> [toggle]
     aliases: [crawl]
     description: Crawl command
+    permission: GSit.Crawl
 
   gsitreload:
 
@@ -109,7 +110,7 @@ permissions:
       GSit.Spin: true
 
   GSit.Lay:
-    default: true
+    default: op
     description: Lay command | Permission
 
   GSit.BellyFlop:
@@ -117,7 +118,7 @@ permissions:
     description: BellyFlop command | Permission
 
   GSit.Spin:
-    default: true
+    default: op
     description: Spin command | Permission
 
   GSit.Crawl.*:
@@ -129,7 +130,7 @@ permissions:
       GSit.CrawlToggle: true
 
   GSit.Crawl:
-    default: true
+    default: op
     description: Crawl command | Permission
 
   GSit.CrawlSneak:


### PR DESCRIPTION
## Summary
- require GSit.Crawl for /crawl command and don't give perms by default
- require GSit.Lay and GSit.Spin only when permission is granted
- adjust Turkish permission error message

## Testing
- `./gradlew tasks --all`
- `./gradlew build` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852ea1752cc8330b4f77e4c277df51c